### PR TITLE
ct_helper: Switch from DSA algorithm to the default of RSA

### DIFF
--- a/src/ct_helper.erl
+++ b/src/ct_helper.erl
@@ -196,8 +196,8 @@ is_process_down(Pid, Timeout) ->
 -spec make_certs()
 	-> {CaCert::der_encoded(), Cert::der_encoded(), Key::key()}.
 make_certs() ->
-	CaInfo = {CaCert, _} = erl_make_certs:make_cert([{key, dsa}]),
-	{Cert, {Asn1Type, Der, _}} = erl_make_certs:make_cert([{key, dsa}, {issuer, CaInfo}]),
+	CaInfo = {CaCert, _} = erl_make_certs:make_cert([]),
+	{Cert, {Asn1Type, Der, _}} = erl_make_certs:make_cert([{issuer, CaInfo}]),
 	{CaCert, Cert, {Asn1Type, Der}}.
 
 %% @doc Create a set of certificates and store them in an ets table.


### PR DESCRIPTION
The created certificate & DSA key don't seem to work properly with Erlang 24 compiled from the `master` branch. If we switch to RSA, then Erlang 24 is happy!

This problem was reported by the RabbitMQ CI when testing [rabbitmq-trust-store](https://github.com/rabbitmq/rabbitmq-trust-store). This can be reproduced with the following example command:
```
gmake distclean-ct ct-system t=http_provider_tests:validate_chain
```

The error is a `function_clause` exception in `ssl_cipler:signature_algorithm_to_scheme/1`:

```
1> (<8293.830.0>) call ssl_cipher:signature_algorithm_to_scheme({'SignatureAlgorithm',
    {1,2,840,10040,4,3},
    {params,
        {'Dss-Parms',
            95968065457980165142901197607130663052306408639930928251894883964912270078048231903354633465567925461909500936265893888084864517243072306771457731304001780429173696991682328911848535934606870398659897117328899321657528878651619552075768019236850380798859227092979974710490887990645285268392160882989041850853,
            732339189046902415198320172842334462427898548261,
            4073740069783599135562647439637474007088909446468908232003228972420909485130935626113753603957226338182729198258161513142933905776095012645998556032747333477884963453647655187701568726403118392965532504689821303202825122582960644709850973726009236013200072302443304941606360038964880460779135057926415462429}}}) ({ssl_certificate,
                                                                                                                                                                                                                                                                                                                                      is_supported_signature_algorithm,
                                                                                                                                                                                                                                                                                                                                      2})
1> (<8293.830.0>) exception_from {ssl_cipher,signature_algorithm_to_scheme,1} {error,function_clause}
1> (<8293.830.0>) exception_from {ssl_certificate,validate,3} {error,function_clause}
1> (<8293.830.0>) returned from ssl_handshake:certify/8 -> {alert,2,80,
                                                         #{file =>
                                                            "ssl_handshake.erl",
                                                           line => 387,
                                                           mfa =>
                                                            {ssl_handshake,
                                                             certify,8}},
                                                         undefined,
                                                         {unexpected_error,
                                                          function_clause}}
```